### PR TITLE
Process value tags with attributes and a multiline body

### DIFF
--- a/lib/Spreadsheet/XLSX.pm
+++ b/lib/Spreadsheet/XLSX.pm
@@ -95,7 +95,7 @@ sub _load_workbook {
         my $s    = 0;
         my $s2   = 0;
         my $sty  = 0;
-        foreach ($member_sheet->contents =~ /(\<.*?\/?\>|.*?(?=\<))/g) {
+        foreach ($member_sheet->contents =~ /(\<.*?\/?\>|(?s).*?(?-s)(?=\<))/g) {
             if (/^\<c\s*.*?\s*r=\"([A-Z])([A-Z]?)(\d+)\"/) {
 
                 ($row, $col) = __decode_cell_name($1, $2, $3);
@@ -104,7 +104,7 @@ sub _load_workbook {
                 $s2  = m/t=\"str\"/    ? 1  : 0;
                 $sty = m/s="([0-9]+)"/ ? $1 : 0;
 
-            } elsif (/^<v>/) {
+            } elsif (/^<v.*?>/) {
                 $parsing_v_tag = 1;
             } elsif (/^<\/v>/) {
                 $parsing_v_tag = 0;


### PR DESCRIPTION
`<v>` tags can have attributes like `<v xml:space="preserve">`. If they have `xml:space="preserve"` set the body and thus the value can consist of multiple lines.

`/^<v.*?>/` now catches opening <v> tags with attributes.
`/(\<.*?\/?\>|(?s).*?(?-s)(?=\<))/g` ensures that multiline bodies are correctly split out.

Example xml snippet that now gets parsed correctly:

```xml
<c r="A1" s="402" t="str"><v>Single line</v></c><c r="A2" s="402" t="str"><v xml:space="preserve">Multiline line1 
 line2</v></c>
```